### PR TITLE
refactor: Improve responsiveness and use CSS classes for styling

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -47,30 +47,22 @@ const renderPokemon = async (pokemon) => {
     pokemonHeight.innerHTML = 'Altura:' + ' ' + (data.height * 0.1).toFixed(2) + ' ' + 'metro(s)';
     pokemonWeight.innerHTML = 'Peso: ' + (data.weight / 10) + 'kg'
 
-    // Verifica a geração do Pokémon e define a imagem apropriada
+    // Reseta as classes de geração e remove a imagem de erro
+    pokemonImage.className = 'pokemon__image';
+
+    // Verifica a geração do Pokémon e define a imagem e a classe apropriada
     if (data.id >= 1 && data.id <= 649) {
       pokemonImage.src = data['sprites']['versions']['generation-v']['black-white']['animated']['front_default'];
-    }
-
-    if (data.id >= 650 && data.id <= 721) {
+      pokemonImage.classList.add('gen-5');
+    } else if (data.id >= 650 && data.id <= 721) {
       pokemonImage.src = data['sprites']['versions']['generation-vi']['x-y']['front_default'];
-      document.querySelector('.pokemon__image').style.width = '10%';
-      document.querySelector('.pokemon__image').style.height = '15%';
-      document.querySelector('.pokemon__image').style.bottom = '50%';
-    }
-
-    if (data.id >= 721 && data.id <= 809) {
+      pokemonImage.classList.add('gen-6');
+    } else if (data.id >= 722 && data.id <= 809) {
       pokemonImage.src = data['sprites']['versions']['generation-vii']['icons']['front_default'];
-      document.querySelector('.pokemon__image').style.width = '16%';
-      document.querySelector('.pokemon__image').style.height = '14%';
-      document.querySelector('.pokemon__image').style.bottom = '50%';
-    }
-
-    if (data.id >= 809 && data.id <= 905) {
+      pokemonImage.classList.add('gen-7');
+    } else if (data.id >= 810 && data.id <= 905) {
       pokemonImage.src = data['sprites']['versions']['generation-viii']['icons']['front_default'];
-      document.querySelector('.pokemon__image').style.width = '16%';
-      document.querySelector('.pokemon__image').style.height = '14%';
-      document.querySelector('.pokemon__image').style.bottom = '49.5%';
+      pokemonImage.classList.add('gen-8');
     }
 
     // Limpa o campo de entrada

--- a/style/style.css
+++ b/style/style.css
@@ -32,12 +32,32 @@ main {
 
 /* Estilo para a imagem do Pokémon */
 .pokemon__image {
-  width: 10%; /* Define a largura como 10% do elemento pai */
-  height: 15%; /* Define a altura como 15% do elemento pai */
-  position: absolute; /* Posiciona o elemento de forma absoluta */
-  bottom: 50%; /* Posiciona o elemento 50% do fundo */
-  left: 27%; /* Posiciona o elemento 27% da esquerda */
-  transform: translate(-63%, 20%); /* Move o elemento para ajustar a posição */
+  position: absolute;
+  bottom: 50%;
+  left: 27%;
+  transform: translate(-63%, 20%);
+}
+
+/* Estilos para cada geração de Pokémon */
+.pokemon__image.gen-5 {
+  width: 10%;
+  height: 15%;
+}
+
+.pokemon__image.gen-6 {
+  width: 10%;
+  height: 15%;
+}
+
+.pokemon__image.gen-7 {
+  width: 16%;
+  height: 14%;
+}
+
+.pokemon__image.gen-8 {
+  width: 16%;
+  height: 14%;
+  bottom: 49.5%;
 }
 
 /* Estilo para os dados do Pokémon (número e nome) */
@@ -99,6 +119,54 @@ main {
 }
 
 /* Media Queries para responsividade */
+@media (max-width: 700px) {
+  .pokedex {
+    max-width: 500px;
+  }
+
+  .pokemon__image {
+    left: 50%;
+    transform: translate(-50%, 20%);
+  }
+
+  .pokemon__image.gen-5,
+  .pokemon__image.gen-6 {
+    width: 15%;
+    height: 12%;
+  }
+
+  .pokemon__image.gen-7,
+  .pokemon__image.gen-8 {
+    width: 18%;
+    height: 14%;
+  }
+
+  .pokemon__data {
+    top: 56%;
+    right: 50%;
+    transform: translateX(50%);
+    font-size: clamp(10px, 3vw, 18px);
+  }
+
+  .pokemon__infos {
+    top: 34%;
+    right: 10%;
+    font-size: clamp(9px, 2.5vw, 15px);
+  }
+
+  .form {
+    top: 75%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 70%;
+  }
+
+  .input__search {
+    width: 100%;
+    font-size: clamp(11px, 3.5vw, 17px);
+  }
+}
+
 @media (max-width: 600px) {
   main {
     margin-top: 10%;


### PR DESCRIPTION
This commit introduces a major refactoring to improve the responsiveness and maintainability of the Pokedex website.

Key changes:

1.  **Refactored JavaScript to use CSS Classes:** The `js/script.js` file was modified to use CSS classes (`gen-5`, `gen-6`, etc.) to style the Pokémon image based on its generation. This eliminates the use of inline styles, making the code cleaner and easier to maintain.
2.  **Added Generation-Specific Styles:** New styles were added to `style/style.css` to support the new generation classes, ensuring that each Pokémon generation's image is displayed correctly.
3.  **Improved Responsiveness for 700px Screens:** A new media query for `max-width: 700px` was added to provide a better layout on tablet-sized screens. This includes adjustments to the Pokedex size, element positioning, and font sizes.